### PR TITLE
Allow forced asset load via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,42 @@ You can then bind buttons to the Service Finder Tool by adding the default trigg
 <button class="$ServiceFinderToolTrigger">Open Service Finder Tool</button>
 ```
 
-The `ServiceFinderTool\ControllerExtension` will inject the necessary Javascript into the page when the trigger is used. This will not work correctly if the element is wrapped in partial caching, in which case you will need to follow the steps below to trigger the injection manually.
+The `SomarDesignStudios\ServiceFinderTool\ControllerExtension` will inject the necessary Javascript into the page when the trigger is used.
+
+## Cached content
+
+The normal method will not work correctly if the element is wrapped with partial caching, in which case you will need to follow the steps below to trigger the injection manually.
+
+### Via configuration
+
+To force the JavaScript to load on every page; add a configuration file `service-finder-tool.yml` with the following
+
+```yaml
+---
+Name: servicefindertool
+Only:
+  moduleexists: 'somardesignstudios/silverstripe-sft-embed'
+---
+SomarDesignStudios\ServiceFinderTool:
+  always_load_script: true
+```
+
+### Via manual implementation
 
 If you want to attach the trigger to an element manually (for example, if the target element does not exist in the DOM during page load):
 
-- Call `ServiceFinderTool\ControllerExtension::requireCoreJS()` from your controller to inject the necessary Javascript
+- Call `SomarDesignStudios\ServiceFinderTool\ControllerExtension::requireCoreJS()` from your controller to inject the necessary Javascript
 - Bind the tool to a button element by calling `window.initServiceFinderTool('<element-css-selector>')`
 
 If you need to open the tool from your own Javascript, you can call `window.triggerServiceFinderTool()` directly, and you can close it by calling `window.closeServiceFinderTool()`.
+
+
 
 ## Security
 
 This module can allow Javascript from a third-party source, and as such should be treated with a level of caution. Theoretically, this could change at any time. As a result, a copy of the Javascript has been included in the module, which will be periodically updated when the remote script is.
 
-By default, the module will use the baked-in version of the Javascript. To shift to using the remote version, add the following to your site config:
+By default, the module will use the baked-in version of the Javascript. To shift to using the remote version, add the following to your config:
 
 ```yaml
 SomarDesignStudios\ServiceFinderTool\ControllerExtension:

--- a/code/ControllerExtension.php
+++ b/code/ControllerExtension.php
@@ -22,6 +22,24 @@ class ControllerExtension extends Extension
     private static $use_remote_js = false;
 
     /**
+     * If enabled then the JavaScript will be loaded on all pages
+     * @config
+     */
+    private static bool $always_load_script = false;
+
+    /**
+     * @inheritDoc
+     */
+    public function onAfterInit()
+    {
+        // load the service finder tool for every page
+        // this is helpful if the tool is included in a cached block
+        if (Config::inst()->get(self::class, 'always_load_script')) {
+            $this->requireCoreJS();
+        }
+    }
+
+    /**
      * Outputs the trigger class that the SFT embed code binds to. Automatically ensures the JS is included on the page.
      *
      * @return string


### PR DESCRIPTION
This adds a new configuration variable to allow the module to be used more easily with markup in a partial cache.

Adding
```yml
SomarDesignStudios\ServiceFinderTool\ControllerExtension:
  always_load_script: true
```
To the site config will force it to load the JavaScript for all pages, instead of just those with the tool enabled.
